### PR TITLE
fix doc for action_report

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,7 +569,7 @@ trigger:
       cluster_id: 65281
       args:
         attribute_id: 84
-        attribute_name: actionReport
+        attribute_name: action_report
         value: 4
 condition: []
 action:


### PR DESCRIPTION
I had to reproduce this configuration and found this little error in the documentation.

`
attribute_name: actionReport
vs
attribute_name: action_report
`